### PR TITLE
Added support for flashvars and a load complete callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ You can also add additional parameters:
   }"></swf-object>
 ```
 
+Specify flash vars:
+
+``` html
+<swf-object
+  swf-url="my-swf.swf"
+  swf-vars="{
+    user: 'alice'
+  }"></swf-object>
+```
+
+Register a callback for swf load complete:
+
+``` html
+<swf-object
+  swf-url="my-swf.swf"
+  swf-load="onLoadHandler()"
+  ></swf-object>
+```
+
 Also supports defining controller level callbacks if using `ExternalInterface` for example:
 
 **View**

--- a/angular-swfobject.js
+++ b/angular-swfobject.js
@@ -1,46 +1,85 @@
 angular.module('swfobject', [])
-  .factory('SwfObject', ['$window', function ($window) {
-    return $window.swfobject;
-  }])
-  .directive('swfObject', ['$window', '$timeout', 'SwfObject', function ($window, $timeout, SwfObject) {
-    'use strict';
+    .factory('SwfObject', ['$window', function ($window) {
+        return $window.swfobject;
+    }])
+    .directive('swfObject', ['$window', '$timeout', '$interval', 'SwfObject', function ($window, $timeout, $interval, SwfObject) {
+        'use strict';
 
-    return {
-      restrict: 'EAC',
-      template: '<div id="{{id}}" ng-transclude></div>',
-      transclude: true,
-      scope: {
-        params: '=swfParams',
-        attrs: '=swfAttrs',
-        callbacks: '=swfCallbacks'
-      },
+        return {
+            restrict: 'EAC',
+            template: '<div id="{{id}}" ng-transclude></div>',
+            transclude: true,
+            scope: {
+                params: '=swfParams',
+                attrs: '=swfAttrs',
+                vars: '=?swfVars',
+                callbacks: '=swfCallbacks',
+                swfLoad: '&'
+            },
 
-      link: function link(scope, element, attrs) {
+            link: function link(scope, element, attrs) {
 
-        scope.id = attrs.swfId || 
-          // Random hash looking thing
-          'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
+                scope.id = attrs.swfId ||
+                    // Random hash looking thing
+                'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
 
-        $timeout(function () {
-          SwfObject.embedSWF(attrs.swfUrl,
-            scope.id,
-            attrs.swfWidth || 800,
-            attrs.swfHeight || 600,
-            attrs.swfVersion || '10',
-            null,
-            null,
-            scope.params,
-            scope.attrs);
-        }, 0);
+                $timeout(function () {
+                    SwfObject.embedSWF(attrs.swfUrl,
+                        scope.id,
+                        attrs.swfWidth || 800,
+                        attrs.swfHeight || 600,
+                        attrs.swfVersion || '10',
+                        null,
+                        scope.vars,
+                        scope.params,
+                        scope.attrs,
+                        embedHandler);
+                }, 0);
 
-        if (scope.callbacks) {
-          var cbs = scope.callbacks;
-          var cbNames = Object.keys(cbs);
+                if (scope.callbacks) {
+                    var cbs = scope.callbacks;
+                    var cbNames = Object.keys(cbs);
 
-          cbNames.forEach(function (cbName) {
-            $window[cbName] = cbs[cbName];
-          });
-        }
-      }
-    };
-  }]);
+                    cbNames.forEach(function (cbName) {
+                        $window[cbName] = cbs[cbName];
+                    });
+                }
+
+
+                // http://learnswfobject.com/advanced-topics/executing-javascript-when-the-swf-has-finished-loading/
+                function swfLoadEvent(evt, fn){
+                    //This timeout ensures we don't try to access PercentLoaded too soon
+                    $timeout(function (){
+                        //Ensure Flash Player's PercentLoaded method is available and returns a value
+                        if(typeof evt.ref.PercentLoaded !== "undefined" && evt.ref.PercentLoaded()){
+                            //Set up a timer to periodically check value of PercentLoaded
+                            var loadCheckInterval = $interval(function (){
+                                //Once value == 100 (fully loaded) we can do whatever we want
+                                if(evt.ref.PercentLoaded() === 100){
+                                    //Clear interval
+                                    $interval.cancel(loadCheckInterval);
+                                    loadCheckInterval = null;
+                                    //Execute function
+                                    fn();
+                                }
+                            }, 1500);
+                        }
+                    }, 200);
+                }
+
+                //This function is invoked by SWFObject once the <object> has been created
+                function embedHandler (evt){
+                    //Only execute if SWFObject embed was successful
+                    if(!evt.success || !evt.ref){
+                        return false;
+                    }
+                    if(scope.swfLoad) {
+                        swfLoadEvent(evt, function () {
+                            scope.swfLoad();
+                        });
+                    }
+
+                }
+            }
+        };
+    }]);

--- a/angular-swfobject.js
+++ b/angular-swfobject.js
@@ -1,85 +1,85 @@
 angular.module('swfobject', [])
-    .factory('SwfObject', ['$window', function ($window) {
-      return $window.swfobject;
-    }])
-    .directive('swfObject', ['$window', '$timeout', '$interval', 'SwfObject', function ($window, $timeout, $interval, SwfObject) {
-      'use strict';
+  .factory('SwfObject', ['$window', function ($window) {
+    return $window.swfobject;
+  }])
+  .directive('swfObject', ['$window', '$timeout', '$interval', 'SwfObject', function ($window, $timeout, $interval, SwfObject) {
+    'use strict';
 
-      return {
-        restrict: 'EAC',
-        template: '<div id="{{id}}" ng-transclude></div>',
-        transclude: true,
-        scope: {
-          params: '=swfParams',
-          attrs: '=swfAttrs',
-          vars: '=?swfVars',
-          callbacks: '=swfCallbacks',
-          swfLoad: '&'
-        },
+    return {
+      restrict: 'EAC',
+      template: '<div id="{{id}}" ng-transclude></div>',
+      transclude: true,
+      scope: {
+        params: '=swfParams',
+        attrs: '=swfAttrs',
+        vars: '=?swfVars',
+        callbacks: '=swfCallbacks',
+        swfLoad: '&'
+      },
 
-        link: function link(scope, element, attrs) {
+      link: function link(scope, element, attrs) {
 
-          scope.id = attrs.swfId ||
-            // Random hash looking thing
-          'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
+        scope.id = attrs.swfId ||
+          // Random hash looking thing
+        'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
 
+        $timeout(function () {
+          SwfObject.embedSWF(attrs.swfUrl,
+              scope.id,
+              attrs.swfWidth || 800,
+              attrs.swfHeight || 600,
+              attrs.swfVersion || '10',
+              null,
+              scope.vars,
+              scope.params,
+              scope.attrs,
+              embedHandler);
+        }, 0);
+
+        if (scope.callbacks) {
+          var cbs = scope.callbacks;
+          var cbNames = Object.keys(cbs);
+
+          cbNames.forEach(function (cbName) {
+            $window[cbName] = cbs[cbName];
+          });
+        }
+
+
+        // http://learnswfobject.com/advanced-topics/executing-javascript-when-the-swf-has-finished-loading/
+        function swfLoadEvent(evt, fn) {
+          //This timeout ensures we don't try to access PercentLoaded too soon
           $timeout(function () {
-            SwfObject.embedSWF(attrs.swfUrl,
-                scope.id,
-                attrs.swfWidth || 800,
-                attrs.swfHeight || 600,
-                attrs.swfVersion || '10',
-                null,
-                scope.vars,
-                scope.params,
-                scope.attrs,
-                embedHandler);
-          }, 0);
+            //Ensure Flash Player's PercentLoaded method is available and returns a value
+            if (typeof evt.ref.PercentLoaded !== "undefined" && evt.ref.PercentLoaded()) {
+              //Set up a timer to periodically check value of PercentLoaded
+              var loadCheckInterval = $interval(function () {
+                //Once value == 100 (fully loaded) we can do whatever we want
+                if (evt.ref.PercentLoaded() === 100) {
+                  //Clear interval
+                  $interval.cancel(loadCheckInterval);
+                  loadCheckInterval = null;
+                  //Execute function
+                  fn();
+                }
+              }, 1500);
+            }
+          }, 200);
+        }
 
-          if (scope.callbacks) {
-            var cbs = scope.callbacks;
-            var cbNames = Object.keys(cbs);
-
-            cbNames.forEach(function (cbName) {
-              $window[cbName] = cbs[cbName];
+        //This function is invoked by SWFObject once the <object> has been created
+        function embedHandler(evt) {
+          //Only execute if SWFObject embed was successful
+          if (!evt.success || !evt.ref) {
+            return false;
+          }
+          if (scope.swfLoad) {
+            swfLoadEvent(evt, function () {
+              scope.swfLoad();
             });
           }
 
-
-          // http://learnswfobject.com/advanced-topics/executing-javascript-when-the-swf-has-finished-loading/
-          function swfLoadEvent(evt, fn) {
-            //This timeout ensures we don't try to access PercentLoaded too soon
-            $timeout(function () {
-              //Ensure Flash Player's PercentLoaded method is available and returns a value
-              if (typeof evt.ref.PercentLoaded !== "undefined" && evt.ref.PercentLoaded()) {
-                //Set up a timer to periodically check value of PercentLoaded
-                var loadCheckInterval = $interval(function () {
-                  //Once value == 100 (fully loaded) we can do whatever we want
-                  if (evt.ref.PercentLoaded() === 100) {
-                    //Clear interval
-                    $interval.cancel(loadCheckInterval);
-                    loadCheckInterval = null;
-                    //Execute function
-                    fn();
-                  }
-                }, 1500);
-              }
-            }, 200);
-          }
-
-          //This function is invoked by SWFObject once the <object> has been created
-          function embedHandler(evt) {
-            //Only execute if SWFObject embed was successful
-            if (!evt.success || !evt.ref) {
-              return false;
-            }
-            if (scope.swfLoad) {
-              swfLoadEvent(evt, function () {
-                scope.swfLoad();
-              });
-            }
-
-          }
         }
-      };
-    }]);
+      }
+    };
+  }]);

--- a/angular-swfobject.js
+++ b/angular-swfobject.js
@@ -1,85 +1,85 @@
 angular.module('swfobject', [])
     .factory('SwfObject', ['$window', function ($window) {
-        return $window.swfobject;
+      return $window.swfobject;
     }])
     .directive('swfObject', ['$window', '$timeout', '$interval', 'SwfObject', function ($window, $timeout, $interval, SwfObject) {
-        'use strict';
+      'use strict';
 
-        return {
-            restrict: 'EAC',
-            template: '<div id="{{id}}" ng-transclude></div>',
-            transclude: true,
-            scope: {
-                params: '=swfParams',
-                attrs: '=swfAttrs',
-                vars: '=?swfVars',
-                callbacks: '=swfCallbacks',
-                swfLoad: '&'
-            },
+      return {
+        restrict: 'EAC',
+        template: '<div id="{{id}}" ng-transclude></div>',
+        transclude: true,
+        scope: {
+          params: '=swfParams',
+          attrs: '=swfAttrs',
+          vars: '=?swfVars',
+          callbacks: '=swfCallbacks',
+          swfLoad: '&'
+        },
 
-            link: function link(scope, element, attrs) {
+        link: function link(scope, element, attrs) {
 
-                scope.id = attrs.swfId ||
-                    // Random hash looking thing
-                'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
+          scope.id = attrs.swfId ||
+            // Random hash looking thing
+          'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
 
-                $timeout(function () {
-                    SwfObject.embedSWF(attrs.swfUrl,
-                        scope.id,
-                        attrs.swfWidth || 800,
-                        attrs.swfHeight || 600,
-                        attrs.swfVersion || '10',
-                        null,
-                        scope.vars,
-                        scope.params,
-                        scope.attrs,
-                        embedHandler);
-                }, 0);
+          $timeout(function () {
+            SwfObject.embedSWF(attrs.swfUrl,
+                scope.id,
+                attrs.swfWidth || 800,
+                attrs.swfHeight || 600,
+                attrs.swfVersion || '10',
+                null,
+                scope.vars,
+                scope.params,
+                scope.attrs,
+                embedHandler);
+          }, 0);
 
-                if (scope.callbacks) {
-                    var cbs = scope.callbacks;
-                    var cbNames = Object.keys(cbs);
+          if (scope.callbacks) {
+            var cbs = scope.callbacks;
+            var cbNames = Object.keys(cbs);
 
-                    cbNames.forEach(function (cbName) {
-                        $window[cbName] = cbs[cbName];
-                    });
-                }
+            cbNames.forEach(function (cbName) {
+              $window[cbName] = cbs[cbName];
+            });
+          }
 
 
-                // http://learnswfobject.com/advanced-topics/executing-javascript-when-the-swf-has-finished-loading/
-                function swfLoadEvent(evt, fn){
-                    //This timeout ensures we don't try to access PercentLoaded too soon
-                    $timeout(function (){
-                        //Ensure Flash Player's PercentLoaded method is available and returns a value
-                        if(typeof evt.ref.PercentLoaded !== "undefined" && evt.ref.PercentLoaded()){
-                            //Set up a timer to periodically check value of PercentLoaded
-                            var loadCheckInterval = $interval(function (){
-                                //Once value == 100 (fully loaded) we can do whatever we want
-                                if(evt.ref.PercentLoaded() === 100){
-                                    //Clear interval
-                                    $interval.cancel(loadCheckInterval);
-                                    loadCheckInterval = null;
-                                    //Execute function
-                                    fn();
-                                }
-                            }, 1500);
-                        }
-                    }, 200);
-                }
+          // http://learnswfobject.com/advanced-topics/executing-javascript-when-the-swf-has-finished-loading/
+          function swfLoadEvent(evt, fn) {
+            //This timeout ensures we don't try to access PercentLoaded too soon
+            $timeout(function () {
+              //Ensure Flash Player's PercentLoaded method is available and returns a value
+              if (typeof evt.ref.PercentLoaded !== "undefined" && evt.ref.PercentLoaded()) {
+                //Set up a timer to periodically check value of PercentLoaded
+                var loadCheckInterval = $interval(function () {
+                  //Once value == 100 (fully loaded) we can do whatever we want
+                  if (evt.ref.PercentLoaded() === 100) {
+                    //Clear interval
+                    $interval.cancel(loadCheckInterval);
+                    loadCheckInterval = null;
+                    //Execute function
+                    fn();
+                  }
+                }, 1500);
+              }
+            }, 200);
+          }
 
-                //This function is invoked by SWFObject once the <object> has been created
-                function embedHandler (evt){
-                    //Only execute if SWFObject embed was successful
-                    if(!evt.success || !evt.ref){
-                        return false;
-                    }
-                    if(scope.swfLoad) {
-                        swfLoadEvent(evt, function () {
-                            scope.swfLoad();
-                        });
-                    }
-
-                }
+          //This function is invoked by SWFObject once the <object> has been created
+          function embedHandler(evt) {
+            //Only execute if SWFObject embed was successful
+            if (!evt.success || !evt.ref) {
+              return false;
             }
-        };
+            if (scope.swfLoad) {
+              swfLoadEvent(evt, function () {
+                scope.swfLoad();
+              });
+            }
+
+          }
+        }
+      };
     }]);

--- a/angular-swfobject.js
+++ b/angular-swfobject.js
@@ -12,8 +12,8 @@ angular.module('swfobject', [])
       scope: {
         params: '=swfParams',
         attrs: '=swfAttrs',
-        vars: '=?swfVars',
         callbacks: '=swfCallbacks',
+        vars: '=?swfVars',
         swfLoad: '&'
       },
 
@@ -21,19 +21,19 @@ angular.module('swfobject', [])
 
         scope.id = attrs.swfId ||
           // Random hash looking thing
-        'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
+          'swf-' + Math.floor(Math.random() * 1000000000000).toString(16);
 
         $timeout(function () {
           SwfObject.embedSWF(attrs.swfUrl,
-              scope.id,
-              attrs.swfWidth || 800,
-              attrs.swfHeight || 600,
-              attrs.swfVersion || '10',
-              null,
-              scope.vars,
-              scope.params,
-              scope.attrs,
-              embedHandler);
+            scope.id,
+            attrs.swfWidth || 800,
+            attrs.swfHeight || 600,
+            attrs.swfVersion || '10',
+            null,
+            scope.vars,
+            scope.params,
+            scope.attrs,
+            embedHandler);
         }, 0);
 
         if (scope.callbacks) {


### PR DESCRIPTION
Hi @jeef3 , I added two additional directive attributes:  swf-vars and swf-load.  swf-vars support the specification of flashvars on the swf object.  Use swf-load to register a callback on swf load complete.

The README file was updated to reflect these modifications.  
