### PR TITLE
Update to allow flash to load when not visible

### DIFF
--- a/angular-swfobject.js
+++ b/angular-swfobject.js
@@ -49,12 +49,10 @@ angular.module('swfobject', [])
 
         // http://learnswfobject.com/advanced-topics/executing-javascript-when-the-swf-has-finished-loading/
         function swfLoadEvent(evt, fn) {
-          //This timeout ensures we don't try to access PercentLoaded too soon
-          $timeout(function () {
-            //Ensure Flash Player's PercentLoaded method is available and returns a value
-            if (typeof evt.ref.PercentLoaded !== "undefined" && evt.ref.PercentLoaded()) {
-              //Set up a timer to periodically check value of PercentLoaded
-              var loadCheckInterval = $interval(function () {
+            //Set up a timer to periodically check value of PercentLoaded
+            var loadCheckInterval = $interval(function () {
+              //Ensure Flash Player's PercentLoaded method is available and returns a value
+              if (typeof evt.ref.PercentLoaded !== "undefined" && evt.ref.PercentLoaded()) {
                 //Once value == 100 (fully loaded) we can do whatever we want
                 if (evt.ref.PercentLoaded() === 100) {
                   //Clear interval
@@ -63,9 +61,8 @@ angular.module('swfobject', [])
                   //Execute function
                   fn({evt: evt});
                 }
-              }, 1500);
-            }
-          }, 200);
+              }
+            }, 200);
         }
 
         // https://code.google.com/p/swfobject/wiki/api


### PR DESCRIPTION
Refresh a page containing this directive and change tabs in your browser before it is done loading. The previous timeout event would fire and the evt.ref.PercentLoaded was undefined. The timeout would not continue and the swfLoad event would never load. This change just removes the timeout and sets the interval so it will continue to check.
